### PR TITLE
bugfix: meeting 게시글 소유권 문제 해결

### DIFF
--- a/src/main/java/com/estsoft13/matdori/config/WebSecurityConfig.java
+++ b/src/main/java/com/estsoft13/matdori/config/WebSecurityConfig.java
@@ -39,7 +39,7 @@ public class WebSecurityConfig {
                         auth.requestMatchers("/files/**","/","/css/**", "/login", "/signup", "/forgot","/user", "/admin/new", "/reviews").permitAll()
                                 .requestMatchers("/admin/manage", "/restaurants").hasRole("ADMIN")
                                 .requestMatchers("/meetings").hasAnyRole("ASSOCIATE","MEMBER","ADMIN")
-                                .requestMatchers("/meeting/**").hasAnyRole("MEMBER","ADMIN")
+//                                .requestMatchers("/meeting/**").hasAnyRole("MEMBER","ADMIN")
                                 .anyRequest().authenticated())
                 .formLogin(auth -> auth.loginPage("/login")
                         .usernameParameter("email")

--- a/src/main/java/com/estsoft13/matdori/controller/meeting/MeetingController.java
+++ b/src/main/java/com/estsoft13/matdori/controller/meeting/MeetingController.java
@@ -1,11 +1,13 @@
 package com.estsoft13.matdori.controller.meeting;
 
+import com.estsoft13.matdori.domain.User;
 import com.estsoft13.matdori.dto.meeting.AddMeetingRequestDto;
 import com.estsoft13.matdori.dto.meeting.MeetingResponseDto;
 import com.estsoft13.matdori.dto.meeting.UpdateMeetingDto;
 import com.estsoft13.matdori.service.MeetingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,8 +26,8 @@ public class MeetingController {
 
     // 모임 하나 조회
     @GetMapping("/api/meeting/{meetingId}")
-    public MeetingResponseDto getOneMeeting(@PathVariable Long meetingId) {
-        return meetingService.getOneMeeting(meetingId);
+    public MeetingResponseDto getOneMeeting(@PathVariable Long meetingId, @AuthenticationPrincipal User user) {
+        return meetingService.getOneMeeting(meetingId, user);
     }
 
     // 모임 생성

--- a/src/main/java/com/estsoft13/matdori/controller/meeting/MeetingPageController.java
+++ b/src/main/java/com/estsoft13/matdori/controller/meeting/MeetingPageController.java
@@ -5,7 +5,6 @@ import com.estsoft13.matdori.domain.Restaurant;
 import com.estsoft13.matdori.domain.User;
 import com.estsoft13.matdori.dto.comment.CommentResponseDto;
 import com.estsoft13.matdori.dto.meeting.MeetingResponseDto;
-import com.estsoft13.matdori.repository.CommentRepository;
 import com.estsoft13.matdori.service.CommentService;
 import com.estsoft13.matdori.service.MeetingService;
 import com.estsoft13.matdori.service.RestaurantService;
@@ -49,7 +48,7 @@ public class MeetingPageController {
     public String showMeetingDetail(@PathVariable Long meetingId, Model model, @AuthenticationPrincipal User user) {
 
         try {
-            MeetingResponseDto responseDto = meetingService.findById(meetingId);
+            MeetingResponseDto responseDto = meetingService.getOneMeeting(meetingId, user);
             model.addAttribute("meeting", responseDto);
 
             // 현재 로그인한 유저가 글을 등록한 유저인지 확인 후 글을 수정할 수 있게끔

--- a/src/main/java/com/estsoft13/matdori/domain/Meeting.java
+++ b/src/main/java/com/estsoft13/matdori/domain/Meeting.java
@@ -85,7 +85,7 @@ public class Meeting {
 
     public MeetingResponseDto toOneResponse() {
        return MeetingResponseDto.builder()
-                .content(content).
+                .content(content).user_id(user.getId()).
                 title(title).location(location).restaurant(restaurant)
                .created_at(created_at).visitTime(visitTime)
                .build();

--- a/src/main/java/com/estsoft13/matdori/dto/meeting/MeetingResponseDto.java
+++ b/src/main/java/com/estsoft13/matdori/dto/meeting/MeetingResponseDto.java
@@ -34,7 +34,8 @@ public class MeetingResponseDto {
     //private Long user_id;
     @Builder
     public MeetingResponseDto(Long id, String title, String content, Restaurant restaurant,
-                              String location, LocalDateTime created_at, String username, String visitTime) {
+                              String location, LocalDateTime created_at, String username, String visitTime
+                                ,Long user_id) {
         this.id = id;
         this.title = title;
         this.content = content;
@@ -43,6 +44,7 @@ public class MeetingResponseDto {
         this.username = username;
         this.restaurant = restaurant;
         this.visitTime = visitTime;
+        this.user_id = user_id;
     }
 
     public MeetingResponseDto(Meeting meeting) {

--- a/src/main/java/com/estsoft13/matdori/service/MeetingService.java
+++ b/src/main/java/com/estsoft13/matdori/service/MeetingService.java
@@ -10,8 +10,10 @@ import com.estsoft13.matdori.repository.CommentRepository;
 import com.estsoft13.matdori.repository.MeetingRepository;
 import com.estsoft13.matdori.repository.RestaurantRepository;
 import com.estsoft13.matdori.repository.UserRepository;
+import com.estsoft13.matdori.util.Role;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -46,9 +48,16 @@ public class MeetingService {
 
     // 특정 모임 조회 서비스
     @Transactional
-    public MeetingResponseDto getOneMeeting(Long meetingId) {
-        return meetingRepository.findById(meetingId)
+    public MeetingResponseDto getOneMeeting(Long meetingId, User user) {
+        MeetingResponseDto meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 모임이 존재하지 않습니다.")).toOneResponse();
+
+        if (meeting.getUser_id().equals(user.getId()) || user.getRole().equals(Role.ROLE_MEMBER)
+        ||user.getRole().equals(Role.ROLE_ADMIN)) {
+            return meeting;
+        } else {
+            throw new AccessDeniedException("Access denied");
+        }
     }
 
     // 모임 생성 서비스

--- a/src/main/resources/static/css/detailedReview.css
+++ b/src/main/resources/static/css/detailedReview.css
@@ -114,6 +114,7 @@ body {
     border-bottom: 1px solid rgba(0, 0, 0, 0.3);
     padding-bottom: 12px;
     margin-bottom: 44px;
+    overflow-wrap: break-word;
 }
 
 .reviewtitle {


### PR DESCRIPTION
1. ASSOCIATE유저는 MEETING 게시글조회를 할 수 없는데 자신이 작성한 글도 조회하지 못하는 문제 발생 
-> ASSOCIATE유저는 자신이 쓴 MEETING게시글을 조회할 수 있고(수정) 다른 게시글 조회는 MEMEBER로 승급해야만 가능(유지)

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
